### PR TITLE
Avoid using nullish coalesce for node LTS support

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -15,8 +15,11 @@ module.exports = (snowpackConfig, pluginOptions) => {
     },
     onChange({ filePath }) {
       let relativePath = path.relative(process.cwd(), filePath);
+      let purge = tailwindConfig.purge.content !== null && tailwindConfig.purge.content !== void 0
+        ? tailwindConfig.purge.content
+        : tailwindConfig.purge;
 
-      if (!micromatch.isMatch(relativePath, tailwindConfig.purge.content ?? tailwindConfig.purge)) {
+      if (!micromatch.isMatch(relativePath, purge)) {
         return;
       }
 


### PR DESCRIPTION
Fixes https://github.com/JadeX/snowpack-plugin-tailwindcss-jit/issues/3

A coworker of mine has node LTS v12.19.0 installed, and this breaks for them because `??` doesn't exist until node v14 unfortunately.